### PR TITLE
Make it possible to run Reina with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.8
+
+RUN apt update && apt install -y libfreetype6-dev libpng-dev libqhull-dev pkg-config \
+    gcc gfortran libopenblas-dev liblapack-dev cython
+
+RUN mkdir /app /src
+WORKDIR /app
+COPY . /app
+
+# We check out editable installs (numpy) to /src, so that we can
+# mount development directory to /app if we want,
+# and numpy won't be suddenly missing. By default, numpy would be
+# installed to /app/src
+RUN pip install -r requirements.txt --src /src
+RUN export PYTHONPATH="${PYTHONPATH}:/src"
+
+
+RUN pybabel compile -d locale
+
+EXPOSE 8123
+ENTRYPOINT ["python", "-m", "corona", "--externally-visible"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ Or visualize using Dash:
 python -m corona
 ```
 
+## Installing and running with Docker
+
+Alternatively, you can run Reina with [Docker](https://www.docker.com/). To start with, build the image (this will take a while):
+
+```
+docker build . -t reina
+```
+
+Then you can start a container that runs Dash visualizations, at localhost:8123:
+
+```
+docker run -p 127.0.0.1:8123:8123 --name reina --rm -v $(pwd):/app reina
+```
+
+While the container is running, you can run the simulation like this:
+
+```
+docker exec -ti reina python -m calc.simulation
+```
+
 ## Development
 
 ### Localisation

--- a/corona.py
+++ b/corona.py
@@ -10,6 +10,7 @@ from common import cache
 from common.locale import init_locale, get_active_locale
 import uuid
 import os
+import sys
 import dash_table
 import dash_core_components as dcc
 import dash_html_components as html
@@ -615,4 +616,7 @@ if __name__ == '__main__':
     # Write the process pid to a file for easier profiling with py-spy
     with open('.corona.pid', 'w') as pid_file:
         pid_file.write(str(os.getpid()))
-    app.run_server(debug=True, port=8123)
+    kwargs = {}
+    if '--externally-visible' in sys.argv:
+        kwargs['host'] = '0.0.0.0'
+    app.run_server(debug=True, port=8123, **kwargs)


### PR DESCRIPTION
This pull request adds support for running Reina with Docker. This should make it more convenient to run, particularly for people on Windows and Macs.

- Added Dockerfile
- Added "--externally-visible" flag to corona.py that makes it possible to serve from a Docker container.
- Added instructions to README.md for running with Docker

The one part that doesn't work is showing the actual Dash graphs, at localhost:8123. I have no idea why that is, the behaviour in web console seems to be the same as here: https://korona.kausal.tech/sim/ . Any idea what may be the cause?