### PR TITLE
Use docker-compose to include Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,14 @@ python -m corona
 
 ## Installing and running with Docker
 
-Alternatively, you can run Reina with [Docker](https://www.docker.com/). To start with, build the image (this will take a while):
+Alternatively, you can run Reina with [Docker](https://www.docker.com/).
+To do so, run:
 
 ```
-docker build . -t reina
+docker-compose up
 ```
 
-Then you can start a container that runs Dash visualizations, at localhost:8123:
-
-```
-docker run -p 127.0.0.1:8123:8123 --name reina --rm -v $(pwd):/app reina
-```
+The first time you run it, it will build the container for Reina, which takes some time. Once it's done, Reina Dash visualization is available at localhost:8123.
 
 While the container is running, you can run the simulation like this:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+    reina:
+        build:
+            context: .
+        container_name: reina
+        restart: unless-stopped
+        environment:
+            - REDIS_URL=redis://redis:6379
+        ports:
+            - "127.0.0.1:8123:8123"
+        volumes:
+            - .:/app
+    redis:
+        image: redis
+        restart: unless-stopped


### PR DESCRIPTION
Currently Reina Dash visualizations won't run without Redis configured. Run Reina container via docker-compose so that it uses a Redis container that starts along with it. 